### PR TITLE
Symlink confuses Windows.

### DIFF
--- a/examples/inputs.py
+++ b/examples/inputs.py
@@ -1,1 +1,0 @@
-../inputs.py


### PR DESCRIPTION
Symlink in examples directory was there to help python newbies to use the examples, however it makes chaos on Windows.