### PR TITLE
Added daemon to InputDevice._pipe on line 2533

### DIFF
--- a/inputs.py
+++ b/inputs.py
@@ -2530,7 +2530,7 @@ class InputDevice(object):  # pylint: disable=useless-object-inheritance
 
             self.__pipe, child_conn = Pipe(duplex=False)
             self._listener = Process(target=target_function,
-                                     args=(child_conn,))
+                                     args=(child_conn,), daemon=True)
             self._listener.start()
         return self.__pipe
 


### PR DESCRIPTION
This fixes:
https://github.com/zeth/inputs/issues/23#issuecomment-443534823
I ran the tests on my Windows machine and the tests all ran exactly the same before and after adding the fix. Perhaps a test should be written looking at the exit command, but I'm not sure if that would fail without the daemon.