### PR TITLE
Fix empty type_codes

### DIFF
--- a/inputs.py
+++ b/inputs.py
@@ -1299,7 +1299,7 @@ CURRENT = ()
 
 EVENT_MAP = (
     ('types', EVENT_TYPES),
-    ('type_codes', ((value, key) for key, value in EVENT_TYPES)),
+    ('type_codes', tuple((value, key) for key, value in EVENT_TYPES)),
     ('wincodes', WINCODES),
     ('specials', SPECIAL_DEVICES),
     ('xpad', XINPUT_MAPPING),


### PR DESCRIPTION
if call `DeviceManager` outside of the module, `self.code['type_codes']`
could be always empty