### PR TITLE
Fixed an error relating to rumbe states

### DIFF
--- a/inputs.py
+++ b/inputs.py
@@ -1285,7 +1285,7 @@ MAC_KEYS = (
 # We have yet to support force feedback but probably should
 # eventually:
 
-FORCE_FEEDBACK = ()  # Motor in gamepad
+FORCE_FEEDBACK = (((i, hex(i)) for i in range(0, 65536)))  # Motor in gamepad
 FORCE_FEEDBACK_STATUS = ()  # Status of motor
 
 POWER = ()  # Power switch


### PR DESCRIPTION
Fixed an being raied when rumble state changed by external library stopping the inputs library from being able to read the state of the controller. If this is not changed, the library instead throws an error when reading the controller state using get_gamepad() after the rumble state has been changed.