### PR TITLE
Update setup.py to use find_packages() to include all subpackages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from __future__ import with_statement
 import platform
 
-from setuptools import setup
+from setuptools import setup, find_packages
 
 import inputs
 
@@ -39,7 +39,7 @@ KWARGS = {
     "version": inputs.__version__,
     "author": "Zeth",
     "author_email": "theology@gmail.com",
-    "packages": ["inputs"],
+    "packages": find_packages(),
     "long_description": INPUTS_LONG_DESCRIPTION,
     "license": "BSD",
     "classifiers": INPUTS_CLASSIFIERS,


### PR DESCRIPTION
when using "packages": ["inputs"], the items in the subdir, such as devices, gets left out and yields an incomplete install of the python package.